### PR TITLE
fix: increased password length

### DIFF
--- a/managed-stack/main.tf
+++ b/managed-stack/main.tf
@@ -1,6 +1,6 @@
 # This resource here is to show you how plan policies work.
 
 resource "random_password" "secret" {
-  length  = 8
+  length  = 20
   special = true
 }


### PR DESCRIPTION
Password length for this managed stack example does not meet the minimum requirements (16 characters). 

![Screenshot 2024-05-07 at 11 17 01 AM](https://github.com/spacelift-io/terraform-starter/assets/3866278/b14f168c-c392-403a-8948-e43973a7f32d)

Increased to the recommended length (20 characters).
