### PR TITLE
Chore: Fix “Getting Started” link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Terraform Starter With Spacelift
 
-This repository is used with our getting-started documentation [here](https://docs.spacelift.io/getting-started).
+This repository is used with our getting-started documentation [here](https://docs.spacelift.io/).
 Follow along with that tutorial to get started with Terraform and Spacelift.


### PR DESCRIPTION
I was looking to follow the Getting Started tutorial, but the link in the readme on this repo is broken. This should fix it!